### PR TITLE
Fix/improve datetime retrieval from DM3 metadata tags

### DIFF
--- a/holoaverage/dm3.py
+++ b/holoaverage/dm3.py
@@ -660,13 +660,11 @@ def parse_known_metadata_tags(tags):
     # Timestamp
     if ('DataBar:Acquisition Date' in tags) and ('DataBar:Acquisition Time' in tags):
         date_string = tags['DataBar:Acquisition Date'].as_string()
-        time_string = tags['DataBar:Acquisition Time'].as_string().split(' ')
-        import datetime
-        date = datetime.datetime.strptime(date_string, '%m/%d/%Y').date()
-        time = datetime.datetime.strptime(time_string[0], '%I:%M:%S').time()
-        timestamp = datetime.datetime.combine(date, time)
-        if time_string[1].upper() == 'PM':
-            timestamp += datetime.timedelta(hours=12)
+        time_string = tags['DataBar:Acquisition Time'].as_string()
+
+        from dateutil.parser import parse
+
+        timestamp = parse('%s %s' % (date_string, time_string), dayfirst=False, yearfirst=False)
         result['timestamp'] = timestamp.isoformat('T')
 
     return result

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Topic :: Scientific/Engineering :: Chemistry',
         'Topic :: Scientific/Engineering :: Physics',
     ],
-    install_requires=['numpy', 'scipy', 'h5py'],
+    install_requires=['numpy', 'scipy', 'h5py', 'python-dateutil'],
     extras_require={
         'rst': ['docutils>=0.11'],
         'fftw': ['pyfftw'],


### PR DESCRIPTION
Currently, `holoaverage` assumes the date to be in the format `'%m/%d/%Y'` and the time to be in `'%I:%M:%S'`. Some DM3 files, however, store the time in 24H format instead of 12H (AM/PM). Instead of trying to check/try all different combinations of formatting the date and time (which there are many), we can just use the `dateutil` package, which intelligently figures out the proper formatting.

I tested the PR against both 24H and 12H (AM/PM) formatted files, and both seem to work.