### PR TITLE
Replace deprecated NumPy functions

### DIFF
--- a/holoaverage/hdf5.py
+++ b/holoaverage/hdf5.py
@@ -92,10 +92,10 @@ def setH5Image(dataset, vmin, vmax):
     if vmax is None:
         vmax = np.amax(dataset)
     vrange = (vmin, vmax)
-    dataset.attrs[b'CLASS'] = np.string_('IMAGE')
-    dataset.attrs[b'IMAGE_SUBCLASS'] = np.string_('IMAGE_GRAYSCALE')
+    dataset.attrs[b'CLASS'] = np.bytes_('IMAGE')
+    dataset.attrs[b'IMAGE_SUBCLASS'] = np.bytes_('IMAGE_GRAYSCALE')
     dataset.attrs[b'IMAGE_WHITE_IS_ZERO'] = np.uint8(0)
-    dataset.attrs[b'DISPLAY_ORIGIN'] = np.string_('UL')
+    dataset.attrs[b'DISPLAY_ORIGIN'] = np.bytes_('UL')
     dataset.attrs[b'IMAGE_MINMAXRANGE'] = np.array(vrange, dtype=dataset.dtype)
 
 

--- a/holoaverage/series.py
+++ b/holoaverage/series.py
@@ -182,8 +182,8 @@ class AbstractSeries(object):
             shape : Shape of datasets
             dtype : Type of datasets
         """
-        indexShape = np.cast[int](np.atleast_1d(indexShape))
-        shape = np.cast[int](np.atleast_1d(shape))
+        indexShape = np.atleast_1d(indexShape).astype(int)
+        shape = np.atleast_1d(shape).astype(int)
         self._shape = tuple(shape)
         self._size = np.prod(shape)
         self._indexShape = tuple(indexShape)
@@ -549,4 +549,3 @@ class LazyLoadingSeries(AbstractSeries):
             for i in range(1, len(listOfNames)):
                 print("\t[%02d] %s" % (i, os.path.basename(listOfNames[i])))
         return result
-


### PR DESCRIPTION
Since the release of [NumPy version 2.0](https://numpy.org/doc/stable/release/2.0.0-notes.html), various functions have been deprecated.

In detail:

- `np.cast` has been removed. The literal replacement for `np.cast[dtype](arg)` is `np.asarray(arg, dtype=dtype)`
- Alias `np.string_` has been removed. Use `np.bytes_` instead

This PR addresses these changes by replacing the above-mentioned API removals with their suggested replacements or equivalent functions.